### PR TITLE
feat: Add short usage to library call

### DIFF
--- a/src/query-face.js
+++ b/src/query-face.js
@@ -371,6 +371,15 @@ export default function QueryFace() {
     return getQueriesByType(queryType);
   }
 
+  function groupBy() {
+    const [queryType, ...columns] = [...arguments];
+    if (columns.some(column => isNotString(column))) {
+      throw new Error(`${queryType} -> parameters must be string`);
+    }
+    extendQuery(queryType, columns);
+    return getQueriesByType(queryType);
+  }
+
   function orderBy() {
     const [queryType, columns, direction = 'asc'] = [...arguments];
     if (arguments.length === 2) {
@@ -1408,7 +1417,7 @@ export default function QueryFace() {
      *   .groupBy('age');
      */
     [SUPPORTED_QUERIES.GROUP_BY]: function(column) {
-      return aggregate(SUPPORTED_QUERIES.GROUP_BY, ...arguments);
+      return groupBy(SUPPORTED_QUERIES.GROUP_BY, ...arguments);
     },
 
     /**

--- a/src/query-face.js
+++ b/src/query-face.js
@@ -1,6 +1,6 @@
 import { isFunction } from './utils/function';
 import { isObject } from './utils/object';
-import { isNotString } from './utils/string';
+import { isNotString, isString } from './utils/string';
 import {
   SUPPORTED_QUERIES,
   RETURN_QUERIES_BY_TYPE,
@@ -68,7 +68,7 @@ export default function QueryFace() {
   /**
    * initial configuration definition if there are any
    */
-  const {
+  let {
     dbName = Config.get('dbName'),
     queryName,
     params,
@@ -91,7 +91,7 @@ export default function QueryFace() {
    *  // queryBuilder is new innerQuery instance of QueryFace class.
    * })
    */
-  let isInnerQuery = arguments[1];
+  let isInnerQuery = arguments[1] === true;
 
   if (!RETURN_QUERIES_BY_TYPE[type]) {
     type = DEFAULT_QUERY_TYPE;
@@ -1938,6 +1938,14 @@ export default function QueryFace() {
     isInnerQuery && delete this[SUPPORTED_QUERIES.RUN];
     return this;
   };
+
+  if (isObject(arguments[1])) {
+    params = arguments[1];
+  }
+  if (isString(arguments[0]) && !isInnerQuery) {
+    queryName = arguments[0];
+    return queries[SUPPORTED_QUERIES.RUN]();
+  }
 
   return getQueriesByType(type);
 }


### PR DESCRIPTION
fix: Update groupBy usage

### short usage
```es6
const params = {};
const result = await qf('queryName', params);
// or
const result = yield qf('queryName', params);
// or
qf('queryName', params).then( result=> {
  // do something here
});
```